### PR TITLE
Add JsonApiAwareInterface so that contexts can opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,23 +62,16 @@ To avoid having to use OAuth to retrieve an access token for each API call you c
 
 ## Usage
 
-To use the step definitions provided by this extension you need to modify your `FeatureContext.php` file to extend the `JsonApiContext` instead of the standard `BehatContext` and call the `parent::construct()` method in the constructor.
+To use the step definitions provided by this extension just load the context class in your suites:
 
-
-```php
-<?php
-
-use Kielabokkie\BehatJsonApi\Context\JsonApiContext;
-
-/**
-  * Defines application features from the specific context.
-  */
-class FeatureContext extends JsonApiContext
-{
-}
+```yaml
+default:
+  suites:
+    default:
+      contexts:
+        - Kielabokkie\BehatJsonApi\Context\JsonApiContext
 ```
-
-When you've made the changes above to your FeatureContext class you get access to the following step definitions:
+You will then have access to the following step definitions:
 
     @Given I use the access token
     @Given I use access token :token
@@ -125,38 +118,12 @@ In some cases you might want to override the base url for a specific suite. Belo
                 paths:
                     - %paths.base%/tests/Behat/features/api
                 contexts:
-                    - FeatureContext: ~
+                    - Kielabokkie\BehatJsonApi\Context\JsonApiContext: ~
             hooks:
                 paths:
                     - %paths.base%/tests/Behat/features/hooks
                 contexts:
-                    - FeatureContext:
+                    - Kielabokkie\BehatJsonApi\Context\JsonApiContext:
                         - http://hooks.yourapp.dev
         extensions:
             Kielabokkie\BehatJsonApi: ~
-
-You also need to add the following to the constructor of your `FeatureContext.php` class.
-
-```php
-<?php
-
-use Kielabokkie\BehatJsonApi\Context\JsonApiContext;
-
-/**
- * Defines application features from the specific context.
- */
-class FeatureContext extends JsonApiContext
-{
-    /**
-     * Initialize the context
-     */
-    public function __construct($baseUrl = null)
-    {
-        parent::__construct();
-
-        if (is_null($baseUrl) === false) {
-            $this->baseUrl = rtrim($baseUrl, '/');
-        }
-    }
-}
-```

--- a/src/Context/Initializer/JsonApiInitializer.php
+++ b/src/Context/Initializer/JsonApiInitializer.php
@@ -2,6 +2,7 @@
 
 use Behat\Behat\Context\Initializer\ContextInitializer;
 use Behat\Behat\Context\Context;
+use Kielabokkie\BehatJsonApi\Context\JsonApiAwareInterface;
 
 class JsonApiInitializer implements ContextInitializer
 {
@@ -34,7 +35,9 @@ class JsonApiInitializer implements ContextInitializer
      */
     public function initializeContext(Context $context)
     {
-        $context->setBaseUrl($this->baseUrl);
-        $context->setParameters($this->parameters);
+        if ($context instanceof JsonApiAwareInterface) {
+            $context->setBaseUrl($this->baseUrl);
+            $context->setParameters($this->parameters);
+        }
     }
 }

--- a/src/Context/JsonApiAwareInterface.php
+++ b/src/Context/JsonApiAwareInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace Kielabokkie\BehatJsonApi\Context;
+
+/**
+ * Interface JsonApiAwareContext.
+ *
+ * @package Kielabokkie\BehatJsonApi\Context
+ */
+interface JsonApiAwareInterface
+{
+
+    /**
+     * Set the base url (specified in behat.yml)
+     *
+     * @param string $baseUrl [description]
+     */
+    public function setBaseUrl($baseUrl);
+
+    /**
+     * Set extension specific parameters (specified in behat.yml)
+     */
+    public function setParameters(array $parameters);
+
+}

--- a/src/Context/JsonApiContext.php
+++ b/src/Context/JsonApiContext.php
@@ -10,7 +10,7 @@ use PHPUnit_Framework_Assert as PHPUnit;
 /**
  * Defines application features from the specific context.
  */
-class JsonApiContext implements SnippetAcceptingContext
+class JsonApiContext implements SnippetAcceptingContext, JsonApiAwareInterface
 {
     /**
      * @var \Buzz\Browser

--- a/src/Context/JsonApiContext.php
+++ b/src/Context/JsonApiContext.php
@@ -825,7 +825,7 @@ class JsonApiContext implements SnippetAcceptingContext, JsonApiAwareInterface
     /**
      * Checks the response exists and returns it.
      *
-     * @return  Guzzle\Http\Message\Response
+     * @return  \Buzz\Message\Response
      */
     protected function getResponse()
     {


### PR DESCRIPTION
The current implementation does not discriminate between JsonApi aware contexts resulting in the extension trying to call `setBaseUrl` and `setParameters` methods also on other contexts.

The current PR solves that by introducing a `JsonApiAwareInterface`: this is a common pattern in Behat.