### PR TITLE
The reserved indicator "%" cannot start a plain scalar.

### DIFF
--- a/src/config/services.yml
+++ b/src/config/services.yml
@@ -12,7 +12,7 @@ services:
   jsonapi.context.initializer:
     class: "%jsonapi.context.initializer.class%"
     arguments:
-      - %jsonapi.base_url%
-      - %jsonapi.parameters%
+      - "%jsonapi.base_url%"
+      - "%jsonapi.parameters%"
     tags:
       -  { name: context.initializer }


### PR DESCRIPTION
This solves the error:
`The reserved indicator "%" cannot start a plain scalar; you need to quote the scalar at line 15 (near "- %jsonapi.base_url%").`

experienced with `"symfony/yaml": "^4.0"`.