### PR TITLE
Fix issue with latest version of Buzz package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+composer.lock
+vendor/

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Author](http://img.shields.io/badge/by-@kielabokkie-lightgrey.svg?style=flat-square)](https://twitter.com/kielabokkie)
 [![Packagist Version](https://img.shields.io/packagist/v/kielabokkie/jsonapi-behat-extension.svg?style=flat-square)](https://packagist.org/packages/kielabokkie/jsonapi-behat-extension)
-[![Codacy Badge](https://img.shields.io/codacy/05bb81bdf72e4dfb8b78e76410ff7605.svg?style=flat-square)](https://www.codacy.com/app/kielabokkie/jsonapi-behat-extension)
+[![Codacy Badge](https://img.shields.io/codacy/grade/05bb81bdf72e4dfb8b78e76410ff7605.svg?style=flat-square)](https://www.codacy.com/app/kielabokkie/jsonapi-behat-extension)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE)
 [![Gitter](https://img.shields.io/badge/gitter-join%20chat-2DCD76.svg?style=flat-square)](https://gitter.im/kielabokkie/jsonapi-behat-extension)
 

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     "require": {
         "php": ">=5.4",
         "behat/behat": "~3.0",
-        "kriswallsmith/buzz": "~0.14",
+        "kriswallsmith/buzz": "0.15.2",
         "phpunit/phpunit": ">=5.7"
     },
     "autoload": {


### PR DESCRIPTION
Lock to version `0.15.2` of the Buzz package to prevent call to undefined method Nyholm\Psr7\Response::getContent() issue as reported here #11 